### PR TITLE
Update nginx-test.yaml

### DIFF
--- a/manifests/nginx-test.yaml
+++ b/manifests/nginx-test.yaml
@@ -36,7 +36,7 @@ spec:
   selector:
     app: nginx
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -49,6 +49,10 @@ spec:
     - host: ocft.nginx-test.doesntexist
       http:
         paths:
-          - backend:
-              serviceName: test-nginx
-              servicePort: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: test-nginx
+                port: 
+                  number: 80


### PR DESCRIPTION
use the updated version of Ingress. Avoid the deprecated warning